### PR TITLE
Fix: Reload and comeback to same page issue (#6)

### DIFF
--- a/React/src/routes/NoAuthRoutes.jsx
+++ b/React/src/routes/NoAuthRoutes.jsx
@@ -1,12 +1,17 @@
 // Create a wrapper component for public pages
-import { Navigate, Outlet } from "react-router";
+import { Navigate, Outlet, useLocation } from "react-router";
 import { useAuth } from "../hooks/useAuth";
 
 function NoAuthRoutes() {
   const { isLoggedIn } = useAuth();
 
+  const location = useLocation();
+
+  // Get the stored location from state, if it exists
+  const from = location.state?.from?.pathname || "/commonpageone";
+
   if (isLoggedIn) {
-    return <Navigate to="/commonpageone" replace />;
+    return <Navigate to={from} replace />;
   }
 
   return <Outlet />;

--- a/React/src/routes/ProtectedRoutes.jsx
+++ b/React/src/routes/ProtectedRoutes.jsx
@@ -1,15 +1,18 @@
 import React, { useContext, useEffect } from "react";
-import { Outlet, useNavigate, Navigate } from "react-router";
+import { Outlet, Navigate, useLocation } from "react-router";
 import { useAuth } from "../hooks/useAuth";
 
 function ProtectedRoutes({ AuthorizedRoles }) {
   let { isLoggedIn, userData } = useAuth();
+  const location = useLocation();
   let hasPermission = userData.roles?.find((role) =>
     AuthorizedRoles.includes(role)
   );
 
+  // console.log(location);
+
   if (!isLoggedIn) {
-    return <Navigate to="/" />;
+    return <Navigate to="/" state={{ from: location }} replace />;
   }
 
   if (!hasPermission) {


### PR DESCRIPTION
This pull request fixes #6 

# 🔍 Issue
- When the page reloads, the signup/login page is briefly loaded.
- Meanwhile, the current-user API is called to fetch data about the logged-in user.
- Once the user data is retrieved, the application navigates to protected routes.
- The first protected route is /commonpageone, causing an unintended redirection.

# ✅ Resolution
- Used useLocation's state prop to store the current location just before reload and use it while navigating in noAuthRouter.jsx

```
// Get the stored location from state, if it exists
  const from = location.state?.from?.pathname || "/commonpageone";

  if (isLoggedIn) {
    return <Navigate to={from} replace />;
  }
```
